### PR TITLE
snowpark-python 0.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,31 +1,29 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "0.6.0" %}
+{% set version = "0.6.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  git_url: git@github.com:snowflakedb/snowpark-python.git
-  git_rev: v{{ version }}
+  url: https://github.com/snowflakedb/snowpark-python/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 5d43eb9cecc126ab7307a1f9d5cbeb7e14aac06817c34e213f7865eb54edfc42
 
 build:
   number: 0
-  noarch: python
-  script:
-    - {{ PYTHON }} -m pip install . --no-deps -vvv
+  skip: True  # [py<38 or py>=39 or win32 or s390x]
+  script: {{ PYTHON }} -m pip install . --no-deps -vvv
 
 requirements:
-  build:
-    - wheel
   host:
-    - python 3.8
+    - python
     - pip
+    - setuptools >=40.6.0
+    - wheel
   run:
-    - python 3.8
-    - cloudpickle >=1.6.0
+    - python
+    - cloudpickle >=1.6.0,<=2.0.0
     - snowflake-connector-python
-    - setuptools >34.0.0
     - typing-extensions >=4.1.0
   run_constrained:
     - pandas >1,<1.4
@@ -37,4 +35,14 @@ test:
 
 about:
   home: https://github.com/snowflakedb/snowpark-python
-  summary: Snowpark Python
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE.txt
+  summary: Snowflake Snowpark Python API
+  description: |
+      The Snowpark library provides intuitive APIs for querying and
+      processing data in a data pipeline. Using this library, you can
+      build applications that process data in Snowflake without having
+      to move data to the system where your application code runs.
+  dev_url: https://github.com/snowflakedb/snowpark-python
+  doc_url: https://github.com/snowflakedb/snowpark-python/blob/main/README.md

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<38 or py>=39 or win32 or s390x]
-  script: {{ PYTHON }} -m pip install . --no-deps -vvv 
+  script: {{ PYTHON }} -m pip install . --no-deps -vvv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<38 or py>=39 or win32 or s390x]
-  script: {{ PYTHON }} -m pip install . --no-deps -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps -vvv 
 
 requirements:
   host:


### PR DESCRIPTION
Changelog: https://github.com/snowflakedb/snowpark-python/blob/v0.6.1/CHANGELOG.md
License: https://github.com/snowflakedb/snowpark-python/blob/v0.6.1/LICENSE.txt
Requirments: https://github.com/snowflakedb/snowpark-python/blob/v0.6.1/setup.py

Actions:
1. Skip py<38 or py>=39 or win32 or s390x
2. Remove noarch: python, and make it arch-specific
3. Add setuptools and wheel in host
4. Add license_family
5. Add dev and doc urls