### PR TITLE
bump to 0.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<38 or py>=39 or win32 or s390x]
+  skip: True  # [py!=38 or win32 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps -vvv 
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "0.8.0" %}
+{% set version = "0.9.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/snowflakedb/snowpark-python/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: a17d3f58f904937583a1a2d1b78aec4f215ed051c1d6043f9f0448e943dfa206
+  sha256: ebf65ab300b691189bc2972f5a81ab635dc91b8cf87c57a1c4f1eb09c409039d
 
 build:
   number: 0
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - cloudpickle >=1.6.0,<=2.0.0
-    - snowflake-connector-python>=2.7.4
+    - snowflake-connector-python>=2.7.11
     - typing-extensions >=4.1.0
   run_constrained:
     - pandas >1,<1.4


### PR DESCRIPTION
Simple version bump
Bumped snowflake-connector-python dependency to 2.7.11 per
https://github.com/snowflakedb/snowpark-python/blob/main/setup.py#L13
All other dependencies remain identical