### PR TITLE
v1.2 bump

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.1.0" %}
-{% set sha256 = "c94f520b928a80348aeb7d4b4d59ea3091fd5620fb03096916e95cf216533b7e" %}
+{% set version = "1.2.0" %}
+{% set sha256 = "5f2b78b61bf81a0ba2bf8cb1586d3c33716073533e65bec067a207bf08d08faa" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
No metadata changes needed here, unless lint disagrees. Dependencies have not changed.

That said, they are experimenting with expanding beyond Python 3.8, and I am going to build another branch of this to host in their snowflake channel. That is not this branch. This is what goes in defaults for now