### PR TITLE
v1.3.0 bump (py38 only)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.2.0" %}
-{% set sha256 = "5f2b78b61bf81a0ba2bf8cb1586d3c33716073533e65bec067a207bf08d08faa" %}
+{% set version = "1.3.0" %}
+{% set sha256 = "55abfe75c4ad7d30305bc6ca78c3ab152a1a4421b8edf8d17c201887b95ac994" %}
 
 package:
   name: {{ name|lower }}
@@ -12,10 +12,10 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<=38 or win32 or s390x]
+  skip: true  # [py<38 or win32 or s390x or py>38 and not test_py39]
   script: {{ PYTHON }} -m pip install . --no-deps -vvv 
   script_env:
-    - SNOWFLAKE_IS_PYTHON_RUNTIME_TEST=1
+    - SNOWFLAKE_IS_PYTHON_RUNTIME_TEST=1  # [test_py39]
 
 requirements:
   host:


### PR DESCRIPTION
No changes to dependencies. Still a Python 3.8 build, but there is now flag (off by default) to allow builds for 3.9 and 3.10. These are not going into defaults and will be handled with a separate build.