### PR TITLE
update 1.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.5.1" %}
-{% set sha256 = "de4be59b246de323967772fcd4276baa8023f54f90413aff88dfb6b60b674d25" %}
+{% set version = "1.6.1" %}
+{% set sha256 = "e29b05ee3d62e0093bbf7cef83814e10a39cfccf3f80573bcb246cdfd4ce5714" %}
 
 package:
   name: {{ name|lower }}
@@ -27,6 +27,7 @@ requirements:
     - cloudpickle >=1.6.0,<=2.0.0
     - snowflake-connector-python >=2.7.12,<4.0.0
     - typing-extensions >=4.1.0,<5.0.0
+    - pyaml
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - python
     - cloudpickle >=1.6.0,<=2.0.0
-    - snowflake-connector-python >=2.7.12,<4.0.0
+    - snowflake-connector-python >=3.0.4,<4.0.0
     - typing-extensions >=4.1.0,<5.0.0
     - pyaml
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python
     - cloudpickle >=1.6.0,<=2.0.0
     - snowflake-connector-python >=3.0.4,<4.0.0
-    - pyaml
+    - pyyaml
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ test:
   imports:
     - snowflake.snowpark
     - snowflake.snowpark._internal
+    - snowflake.snowpark._internal.analyzer
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - python
     - cloudpickle >=1.6.0,<=2.0.0
     - snowflake-connector-python >=3.0.4,<4.0.0
-    - typing-extensions >=4.1.0,<5.0.0
     - pyaml
 
 test:


### PR DESCRIPTION
## ☆ Snowflake-Snowpark-Python Update 1.6.1 (PKG-2577)☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2577)
[Upstream](https://github.com/snowflakedb/snowpark-python)
[Dependencies ](https://github.com/snowflakedb/snowpark-python/blob/v1.6.1)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies