### PR TITLE
Snowflake-Snowpark-Python 1.8.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,12 +20,12 @@ requirements:
   host:
     - python
     - pip
-    - setuptools >=40.6.0
+    - setuptools
     - wheel
   run:
     - python
     - cloudpickle >=1.6.0,<=2.0.0
-    - snowflake-connector-python >=3.0.4,<4.0.0
+    - snowflake-connector-python >=3.2.0,<4.0.0
     - pyyaml
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.7.0" %}
-{% set sha256 = "4f217109dd8f3d4f72b96a5d7324ce78474cc70f18d10172ece1f73664cddf80" %}
+{% set version = "1.8.0" %}
+{% set sha256 = "95b652f5de6f633bc7e41200012adcd4b18f2ffc40f422c5c973336e665464be" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
## ❄️☆Snowflake-Snowpark-Python Update 1.8.0 ☆❄️
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2876)
[Upstream](https://github.com/snowflakedb/snowpark-python)
[Dependencies ](https://github.com/snowflakedb/snowpark-python/blob/v1.8.0)
# Changes
- Updated version number and `sha256`
- Updated `host` and `run` sections