### PR TITLE
snowflake-snowpark-python 1.8.0 for py311 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.7.0" %}
-{% set sha256 = "4f217109dd8f3d4f72b96a5d7324ce78474cc70f18d10172ece1f73664cddf80" %}
+{% set version = "1.8.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,24 +7,23 @@ package:
 
 source:
   url: https://github.com/snowflakedb/snowpark-python/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 95b652f5de6f633bc7e41200012adcd4b18f2ffc40f422c5c973336e665464be
 
 build:
   number: 0
   skip: true  # [py<38 or s390x or py>=311]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
 
-
 requirements:
   host:
     - python
     - pip
-    - setuptools >=40.6.0
+    - setuptools
     - wheel
   run:
     - python
     - cloudpickle >=1.6.0,<=2.0.0
-    - snowflake-connector-python >=3.0.4,<4.0.0
+    - snowflake-connector-python >=3.2.0,<4.0.0
     - pyyaml
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,9 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<38 or s390x or py>=311]
+  skip: true  # [(not py==311) or s390x]
+  script_env:
+    - SNOWFLAKE_IS_PYTHON_RUNTIME_TEST=1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vvv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - wheel
   run:
     - python
-    - cloudpickle >=1.6.0,<=2.0.0
+    - cloudpickle ==2.2.1
     - snowflake-connector-python >=3.2.0,<4.0.0
     - pyyaml
 


### PR DESCRIPTION
**Current package info**


| Channel | Downloads | Version | Platforms | License |
| --- | --- | --- | --- | --- |
| main | [![Conda Downloads](https://img.shields.io/conda/dn/main/snowflake-snowpark-python.svg)](https://anaconda.org/main/snowflake-snowpark-python) | [![Conda Version](https://img.shields.io/conda/vn/main/snowflake-snowpark-python.svg)](https://anaconda.org/main/snowflake-snowpark-python) | [![Conda Platforms](https://img.shields.io/conda/pn/main/snowflake-snowpark-python.svg)](https://anaconda.org/main/snowflake-snowpark-python) | ![Conda License](https://img.shields.io/conda/l/main/snowflake-snowpark-python) |
| sfe1ed40 | [![Conda Downloads](https://img.shields.io/conda/dn/sfe1ed40/snowflake-snowpark-python.svg)](https://anaconda.org/sfe1ed40/snowflake-snowpark-python) | [![Conda Version](https://img.shields.io/conda/vn/sfe1ed40/snowflake-snowpark-python.svg)](https://anaconda.org/sfe1ed40/snowflake-snowpark-python) | [![Conda Platforms](https://img.shields.io/conda/pn/sfe1ed40/snowflake-snowpark-python.svg)](https://anaconda.org/sfe1ed40/snowflake-snowpark-python) | ![Conda License](https://img.shields.io/conda/l/sfe1ed40/snowflake-snowpark-python) |

Changelog: https://github.com/snowflakedb/snowpark-python/releases
License: https://github.com/snowflakedb/snowpark-python/blob/v1.8.0/LICENSE.txt
Requirements: https://github.com/snowflakedb/snowpark-python/blob/v1.8.0/setup.py

Actions:
1.   Skip `[(not py==311) or s390x]`
2. Add  `script_env`: `SNOWFLAKE_IS_PYTHON_RUNTIME_TEST=1` to run a build for **py311** support
3. Remove `pinning` for `setuptools` in `host`
4. Update pinning in `run`: `snowflake-connector-python >=3.2.0,<4.0.0`
5. Use `cloudpickle ==2.2.1` for `py311`

Notes:
- We build **py311** for the `sfe1ed40` channel
- For py311 there is an opened PR https://github.com/AnacondaRecipes/snowpark-python-feedstock/pull/31