### PR TITLE
snowflake-snowpark-python 1.16.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.15.0" %}
+{% set version = "1.16.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/snowflakedb/snowpark-python/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 3e290cd004063073061e841c516a19a396347a839aa0fce01b878353f0f7777b
+  sha256: a5f93130db83e4279add5aeb623a864b315f87109abce77ed3cbbbffa5782b90
 
 build:
   number: 0
@@ -25,8 +25,8 @@ requirements:
   run:
     - python
     - cloudpickle >=1.6.0,<=2.2.1,!=2.1.0,!=2.2.0 # [py<311]
-    - cloudpickle 2.2.1 # [py >=311]
-    - snowflake-connector-python >=3.6.0,<4.0.0
+    - cloudpickle 2.2.1                           # [py>=311]
+    - snowflake-connector-python >=3.10.0,<4.0.0
     - typing-extensions >=4.1.0,<5.0.0
     - pyyaml
     - setuptools >=40.6.0


### PR DESCRIPTION
snowflake-snowpark-python 1.16.0

**Destination channel:** defaults

### Links

- [PKG-4768]
- dev_url: https://github.com/snowflakedb/snowpark-python/tree/v1.16.0
- conda-forge: https://github.com/conda-forge/snowflake-snowpark-python-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/snowflake-snowpark-python/1.16.0
- pypi inspector: https://inspector.pypi.io/project/snowflake-snowpark-python/1.16.0
- upstream diff v1.15.0...v1.16.0: https://github.com/snowflakedb/snowpark-python/compare/v1.15.0...v1.16.0

### Explanation of changes:

- bump version, update 1 dep pinning

[PKG-4768]: https://anaconda.atlassian.net/browse/PKG-4768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ