### PR TITLE
snowflake-snowpark-python 1.17.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.16.0" %}
+{% set version = "1.17.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/snowflakedb/snowpark-python/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: a5f93130db83e4279add5aeb623a864b315f87109abce77ed3cbbbffa5782b90
+  sha256: 8ebaeac4cdede6975ec624e7c3fa8fc8555b7b915784717f815a8899c62f5734
 
 build:
   number: 0
@@ -31,6 +31,10 @@ requirements:
     - pyyaml
     - setuptools >=40.6.0
     - wheel
+  run_constrained:
+    # [pandas] requires modin==0.28.1 and pyarrow (no pinning)
+    - pandas <3.0.0,>=1.0.0
+    - modin ==0.28.1
 
 test:
   requires:


### PR DESCRIPTION
snowflake-snowpark-python 1.17.0

**Destination channel:** defaults

### Links

- [PKG-4829]
- dev_url (pypi): https://github.com/snowflakedb/snowpark-python/tree/v1.17.0
- diff v1.16.0...v1.17.0: https://github.com/snowflakedb/snowpark-python/compare/v1.16.0...v1.17.0
- conda-forge: https://github.com/conda-forge/snowflake-snowpark-python-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/snowflake-snowpark-python/1.17.0
- pypi inspector: https://inspector.pypi.io/project/snowflake-snowpark-python/1.17.0

### Explanation of changes:

- bump version
- add `run_constrained`
