### PR TITLE
snowpark-python 1.21.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @AnacondaRecipes/psubs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.20.0" %}
+{% set version = "1.21.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/snowflakedb/snowpark-python/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: a7e415571cced64bc2befa6c2a915adc0c82c2209dd55d98ccaea52712e34dff
+  sha256: d74af2cbf0d9b92ec9423be2595a21acf07c2b33bf5c5b6aa488c68bb633b601
 
 build:
-  number: 0
+  number: 100
   skip: true  # [py<38 or s390x or py>311]
   script_env:
     - SNOWFLAKE_IS_PYTHON_RUNTIME_TEST=1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ test:
     - snowflake.snowpark._internal
     - snowflake.snowpark._internal.analyzer
     - snowflake.snowpark.mock
+    - snowflake.snowpark._internal.compiler
   commands:
     - pip check
 


### PR DESCRIPTION
snowpark-python 1.21.0

Destination channel: defaults

### Links

- [PKG-5546](https://anaconda.atlassian.net/browse/PKG-5546) 
- [Upstream repository](https://github.com/snowflakedb/snowpark-python)
- [Upstream changelog/diff](https://github.com/snowflakedb/snowpark-python/compare/v1.20.0...v1.21.0 )


### Explanation of changes:

- version 1.21.0 build


[PKG-5546]: https://anaconda.atlassian.net/browse/PKG-5546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ