### PR TITLE
snowflake-snowpark-python 1.22.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.21.1" %}
+{% set version = "1.22.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/snowflakedb/snowpark-python/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: aa2f487cdcccdb29c75b8b2b35704d7a4ad6260bf3251faa6c0ddefd0ba8fbaf
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: a9b96fbbef61e90e578f85c1cb3d46d590bf4a67663d0c284f633234e9352643
 
 build:
   number: 100
@@ -31,11 +31,13 @@ requirements:
     - pyyaml
   run_constrained:
     # modin
-    - pandas <3.0.0,>=1.0.0
+    - pandas >=1.0.0,<3.0.0
     - modin ==0.28.1
     # opentelemetry
     - opentelemetry-api >=1.0.0,<2.0.0
     - opentelemetry-sdk >=1.0.0,<2.0.0
+    # secure-local-storage
+    - keyring >=23.1.0,<26.0.0
 
 test:
   requires:
@@ -44,8 +46,8 @@ test:
     - snowflake.snowpark
     - snowflake.snowpark._internal
     - snowflake.snowpark._internal.analyzer
-    - snowflake.snowpark.mock
     - snowflake.snowpark._internal.compiler
+    - snowflake.snowpark.mock
   commands:
     - pip check
 
@@ -68,5 +70,3 @@ extra:
     - sfc-gh-yixie
     - sfc-gh-achandrasekaran
     - sfc-gh-mkeller
-  skip-lints:
-    - python_build_tool_in_run


### PR DESCRIPTION
snowflake-snowpark-python 1.22.1

**Destination channel:** defaults

### Links

- [PKG-5714]
- dev_url (pypi): https://github.com/snowflakedb/snowpark-python/tree/v1.22.1
- diff: https://github.com/snowflakedb/snowpark-python/compare/v1.21.1...v1.22.1
- conda-forge: https://github.com/conda-forge/snowflake-snowpark-python-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/snowflake-snowpark-python/1.22.1
- pypi inspector: https://inspector.pypi.io/project/snowflake-snowpark-python/1.22.1

### Explanation of changes:

- bump version
- switch to pypi source (I could not figure out why we had used GH until now)
- update run_constrained
- remove skip lint flag
