### PR TITLE
snowflake-snowpark-python 1.23.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,10 +33,13 @@ requirements:
     - pyyaml
   run_constrained:
     # modin
+    - pandas >=1.0.0,<3.0.0
     - modin ==0.28.1
     # opentelemetry
     - opentelemetry-api >=1.0.0,<2.0.0
     - opentelemetry-sdk >=1.0.0,<2.0.0
+    # secure-local-storage
+    - keyring >=23.1.0,<26.0.0
 
 test:
   requires:


### PR DESCRIPTION
snowflake-snowpark-python 1.23.0

**Destination channel:** defaults 

### Links

- [PKG-5899](https://anaconda.atlassian.net/browse/PKG-5899) 
- [Upstream repository](https://github.com/snowflakedb/snowpark-python/tree/v1.23.0)

### Explanation of changes:

- Updated to 1.23.0


[PKG-5899]: https://anaconda.atlassian.net/browse/PKG-5899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ