### PR TITLE
snowflake-snowpark-python 1.24.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.23.0" %}
+{% set version = "1.24.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 47f649ad3a7399ddd3bc714fa42d9845cecbd260039320c406e5471beb334a35
+  sha256: cd8bae93f08f210b57b6ce9c12bca251dd062de57031a496411ac5bfd7fa1105
 
 build:
   # The build number of this package should always start from 100
@@ -40,6 +40,7 @@ requirements:
     - opentelemetry-sdk >=1.0.0,<2.0.0
     # secure-local-storage
     - keyring >=23.1.0,<26.0.0
+
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ requirements:
     # secure-local-storage
     - keyring >=23.1.0,<26.0.0
 
-
 test:
   requires:
     - pip


### PR DESCRIPTION
snowflake-snowpark-python 1.24.0

**Destination channel:** defaults

### Links

- [PKG-6028](https://anaconda.atlassian.net/browse/PKG-6028) 
- [Upstream repository](https://github.com/snowflakedb/snowpark-python/tree/v1.24.0)
- [Upstream diff](https://github.com/snowflakedb/snowpark-python/compare/v1.23.0...v1.24.0)

### Explanation of changes:

- The only dependency change is for the `modin-development` extra, so nothing is modified in the recipe.


[PKG-6028]: https://anaconda.atlassian.net/browse/PKG-6028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ