### PR TITLE
snowpark-python 1.25.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.24.0" %}
+{% set version = "1.25.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: cd8bae93f08f210b57b6ce9c12bca251dd062de57031a496411ac5bfd7fa1105
+  sha256: 184b9f6873b4c318af2727c707000998c9f6e24542036e536d86c2e314549e47
 
 build:
   # The build number of this package should always start from 100
@@ -28,13 +28,15 @@ requirements:
     - python
     - cloudpickle >=1.6.0,<=2.2.1,!=2.1.0,!=2.2.0  # [py<311]
     - cloudpickle 2.2.1                            # [py>=311]
-    - snowflake-connector-python >=3.10.0,<4.0.0
+    - snowflake-connector-python >=3.12.0,<4.0.0
     - typing-extensions >=4.1.0,<5.0.0
     - pyyaml
+    - protobuf >=3.20,<6
+    - tzlocal
   run_constrained:
     # modin
     - pandas >=1.0.0,<3.0.0
-    - modin ==0.28.1
+    - modin ==0.30.1
     # opentelemetry
     - opentelemetry-api >=1.0.0,<2.0.0
     - opentelemetry-sdk >=1.0.0,<2.0.0
@@ -48,7 +50,9 @@ test:
     - snowflake.snowpark
     - snowflake.snowpark._internal
     - snowflake.snowpark._internal.analyzer
+    - snowflake.snowpark._internal.ast
     - snowflake.snowpark._internal.compiler
+    - snowflake.snowpark._internal.proto.generated
     - snowflake.snowpark.mock
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ requirements:
     - pip
     - setuptools >=40.6.0
     - wheel
+    # Required to compile .proto files during setup.py execution
+    - libprotobuf
   run:
     - python
     - cloudpickle >=1.6.0,<=2.2.1,!=2.1.0,!=2.2.0  # [py<311]


### PR DESCRIPTION
snowpark-python 1.25.0 

**Destination channel:** Defaults

### Links

- [PKG-6181]
- dev_url:        https://github.com/snowflakedb/snowpark-python/tree/v1.25.0
- pypi:           https://github.com/snowflakedb/snowpark-python/tree/v1.25.0
- diff: [Comparing v1.24.0...v1.25.0](https://github.com/snowflakedb/snowpark-python/compare/v1.24.0...v1.25.0)

### Explanation of changes:

- Upgraded to v1.25.0


[PKG-6181]: https://anaconda.atlassian.net/browse/PKG-6181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ