### PR TITLE
snowflake-snowpark-python 1.25.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--skip-existing"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - setuptools >=40.6.0
     - wheel
     # Required to compile .proto files during setup.py execution
+    # protoc is provided by protobuf. We do not have a package protoc-wheel.
     - protobuf
     - mypy-protobuf
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   # The build number of this package should always start from 100
   # for new versions. For more information ask the CODEOWNERS.
-  number: 100
+  number: 101
   skip: true  # [py<38 or s390x or py>311]
   script_env:
     - SNOWFLAKE_IS_PYTHON_RUNTIME_TEST=1
@@ -25,7 +25,8 @@ requirements:
     - setuptools >=40.6.0
     - wheel
     # Required to compile .proto files during setup.py execution
-    - libprotobuf
+    - protobuf
+    - mypy-protobuf
   run:
     - python
     - cloudpickle >=1.6.0,<=2.2.1,!=2.1.0,!=2.2.0  # [py<311]


### PR DESCRIPTION
snowflake-snowpark-python 1.25.0

**Destination channel:** defaults

### Links

- [PKG-6366]
- [Upstream repository](https://github.com/snowflakedb/snowpark-python/tree/v1.25.0)

### Explanation of changes:

- Removed `libprotobuf` from `host`, as it brings in undesirable run exports. Replaced with `protobuf and `mypy-protobuf`.
- Added `abs.yaml` parameters to catch this issue early.


[PKG-6366]: https://anaconda.atlassian.net/browse/PKG-6366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ