### PR TITLE
snowflake-snowpark-python 1.26.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,9 @@ requirements:
     - pip
     - setuptools >=40.6.0
     - wheel
+    # For the following protobuf pinnings,
+    # have a look at their recipe/meta.yaml
+    #
     # Snowpark IR
     - protobuf ==3.20.1  # [py<=310]
     - protobuf ==4.25.3  # [py>310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.25.0" %}
+{% set version = "1.26.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 184b9f6873b4c318af2727c707000998c9f6e24542036e536d86c2e314549e47
+  sha256: da982696597057fae66a76ebea8b7a9bc8d05a5f402eba0cbd6c3a8267457208
 
 build:
   # The build number of this package should always start from 100
   # for new versions. For more information ask the CODEOWNERS.
-  number: 101
+  number: 100
   skip: true  # [py<38 or s390x or py>311]
   script_env:
     - SNOWFLAKE_IS_PYTHON_RUNTIME_TEST=1
@@ -24,18 +24,19 @@ requirements:
     - pip
     - setuptools >=40.6.0
     - wheel
-    # Required to compile .proto files during setup.py execution
-    # protoc is provided by protobuf. We do not have a package protoc-wheel.
-    - protobuf
+    # Snowpark IR
+    - protobuf==3.20.1  # [py<=310]
+    - protobuf==4.25.3  # [py>310]
     - mypy-protobuf
   run:
     - python
-    - cloudpickle >=1.6.0,<=2.2.1,!=2.1.0,!=2.2.0  # [py<311]
-    - cloudpickle 2.2.1                            # [py>=311]
+    - cloudpickle >=1.6.0,<=2.2.1,!=2.1.0,!=2.2.0
     - snowflake-connector-python >=3.12.0,<4.0.0
     - typing-extensions >=4.1.0,<5.0.0
     - pyyaml
+    # Snowpark IR
     - protobuf >=3.20,<6
+    - python-dateutil
     - tzlocal
   run_constrained:
     # modin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,8 @@ requirements:
     - setuptools >=40.6.0
     - wheel
     # Snowpark IR
-    - protobuf==3.20.1  # [py<=310]
-    - protobuf==4.25.3  # [py>310]
+    - protobuf ==3.20.1  # [py<=310]
+    - protobuf ==4.25.3  # [py>310]
     - mypy-protobuf
   run:
     - python


### PR DESCRIPTION
snowflake-snowpark-python 1.26.0

**Destination channel:** defaults

### Links

- [PKG-6475]
- dev_url (pypi): https://github.com/snowflakedb/snowpark-python/tree/v1.26.0
- diff: https://github.com/snowflakedb/snowpark-python/compare/v1.25.0...v1.26.0
- conda-forge: https://github.com/conda-forge/snowflake-snowpark-python-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/snowflake-snowpark-python/1.26.0
- pypi inspector: https://inspector.pypi.io/project/snowflake-snowpark-python/1.26.0

### Explanation of changes:

- bump version


[PKG-6475]: https://anaconda.atlassian.net/browse/PKG-6475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ