### PR TITLE
snowpark-python 1.28.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.27.0" %}
+{% set version = "1.28.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 897036020d1cd7f15e041cd6989b48ff3db67ecadba8465ffdfa120e6e1e0d46
+  sha256: 8a39fdc60fe73b04dddc4889ab5ad5a8365a426b66c4a61a66443301f5d3b422
 
 build:
   # The build number of this package should always start from 100


### PR DESCRIPTION
snowpark-python 1.28.0 

**Destination channel:** Defaults

### Links

- [PKG-7229]
- dev_url:        https://github.com/snowflakedb/snowpark-python/tree/v1.26.0
- conda_forge:    https://github.com/conda-forge/snowflake-snowpark-python-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/snowflake-snowpark-python/1.26.0
- pypi inspector: https://inspector.pypi.io/project/snowflake-snowpark-python/1.26.0

### Explanation of changes:

- new version number


[PKG-7229]: https://anaconda.atlassian.net/browse/PKG-7229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ