### PR TITLE
snowpark-python 1.29.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.29.0" %}
+{% set version = "1.29.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 072b99e4ee6765049e26045c839fd961ef46dc64f923f63befac143094750856
+  sha256: cf55b2d49685f91806ad038819559f7698099bb2a503a3306eb4bc62355264e8
 
 build:
   # The build number of this package should always start from 100


### PR DESCRIPTION
snowpark-python 1.29.1 

**Destination channel:** Defaults

### Links

- [PKG-7391]
- dev_url:        https://github.com/snowflakedb/snowpark-python/tree/v1.29.0
- conda_forge:    https://github.com/conda-forge/snowflake-snowpark-python-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/snowflake-snowpark-python/1.29.0
- pypi inspector: https://inspector.pypi.io/project/snowflake-snowpark-python/1.29.0

### Explanation of changes:

- new version number


[PKG-7391]: https://anaconda.atlassian.net/browse/PKG-7391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ