### PR TITLE
snowpark-python 1.30.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.29.1" %}
+{% set version = "1.30.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: cf55b2d49685f91806ad038819559f7698099bb2a503a3306eb4bc62355264e8
+  sha256: 44bfe0bbb99150cbe46037793f5e2938acfe130aa88a51a845c2306dc732662a
 
 build:
   # The build number of this package should always start from 100
@@ -60,6 +60,9 @@ test:
     - snowflake.snowpark._internal.analyzer
     - snowflake.snowpark._internal.ast
     - snowflake.snowpark._internal.compiler
+    - snowflake.snowpark._internal.data_source
+    - snowflake.snowpark._internal.data_source.dbms_dialects
+    - snowflake.snowpark._internal.data_source.drivers
     - snowflake.snowpark._internal.proto.generated
     - snowflake.snowpark.mock
   commands:


### PR DESCRIPTION
snowpark-python 1.30.0 

**Destination channel:** Defaults

### Links

- [PKG-7690]
- dev_url:        https://github.com/snowflakedb/snowpark-python/tree/v1.29.1
- conda_forge:    https://github.com/conda-forge/snowflake-snowpark-python-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/snowflake-snowpark-python/1.29.1
- pypi inspector: https://inspector.pypi.io/project/snowflake-snowpark-python/1.29.1

### Explanation of changes:

- new version number


[PKG-7690]: https://anaconda.atlassian.net/browse/PKG-7690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ