### PR TITLE
snowpark-python 1.36.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.35.0" %}
+{% set version = "1.36.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 07602731ffeb7654095ce1a4fb43f99d8b7f9709cc26485f33de8cf6b1495a33
+  sha256: defcf643905573857772f97f66c8193c20d5ec9089d46a1efdb1cc2f38d75885
 
 build:
   # The build number of this package should always start from 100
@@ -126,7 +126,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    # Requires Snowflake connection to run upstream tests. See: https://github.com/snowflakedb/snowpark-python/blob/v1.33.0/tests/README.md
+    # Requires Snowflake connection to run upstream tests. See: https://github.com/snowflakedb/snowpark-python/blob/v1.36.0/tests/README.md
 
 about:
   home: https://github.com/snowflakedb/snowpark-python


### PR DESCRIPTION
snowpark-python 1.36.0 

**Destination channel:** Defaults

### Links

- [PKG-9133]
- dev_url:        https://github.com/snowflakedb/snowpark-python/tree/v1.35.0
- conda_forge:    None
- pypi:           https://pypi.org/project/snowpark-python/1.36.0
- pypi inspector: https://inspector.pypi.io/project/snowpark-python/1.36.0/

### Explanation of changes:

- new version number
