### PR TITLE
snowpark-python 1.38.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.36.0" %}
+{% set version = "1.38.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: defcf643905573857772f97f66c8193c20d5ec9089d46a1efdb1cc2f38d75885
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 778c40776399c09846c77aa8f9b53773d9c15e793e50c6009eeccafbb43375cc
 
 build:
   # The build number of this package should always start from 100
@@ -32,19 +32,19 @@ requirements:
     - mypy-protobuf
   run:
     - python
-    - cloudpickle >=1.6.0,<=3.0.0,!=2.1.0,!=2.2.0
+    - cloudpickle >=1.6.0,<=3.1.1,!=2.1.0,!=2.2.0
     - snowflake-connector-python >=3.14.0,<4.0.0
     - typing-extensions >=4.1.0,<5.0.0
     - pyyaml
     # Snowpark IR
-    - protobuf >=3.20,<6
+    - protobuf >=3.20,<6.32
     - python-dateutil
     - tzlocal
   run_constrained:
     # modin
-    - pandas >=1.0.0,<3.0.0
+    - pandas <=2.3.1
     # Snowpark pandas requires modin 0.33.x or 0.34.x, which are compatible with pandas 2.2.x
-    - modin >=0.33.0,<0.35.0
+    - modin >=0.34.0,<0.36.0
     # opentelemetry
     - opentelemetry-api >=1.0.0,<2.0.0
     - opentelemetry-sdk >=1.0.0,<2.0.0
@@ -108,6 +108,7 @@ test:
     - snowflake.snowpark._internal.data_source.drivers.pymsql_driver
     - snowflake.snowpark._internal.data_source.drivers.pyodbc_driver
     - snowflake.snowpark._internal.data_source.drivers.sqlite_driver
+    - snowflake.snowpark._internal.data_source.jdbc
     - snowflake.snowpark._internal.data_source.utils
     - snowflake.snowpark._internal.debug_utils
     - snowflake.snowpark._internal.error_message
@@ -123,6 +124,7 @@ test:
     - snowflake.snowpark._internal.udf_utils
     - snowflake.snowpark._internal.utils
     - snowflake.snowpark._internal.xml_reader
+    - snowflake.snowpark._internal.xpath_handlers
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"


### PR DESCRIPTION
snowpark-python 1.38.0 

**Destination channel:** Defaults

### Links

- [PKG-9548]
- dev_url:        https://github.com/snowflakedb/snowpark-python/tree/v1.38.0
- conda_forge:    None
- pypi:           https://pypi.org/project/snowpark-python/1.38.0
- pypi inspector: https://inspector.pypi.io/project/snowpark-python/1.38.0

### Explanation of changes:

- new version number
