### PR TITLE
snowpark-python 1.40.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.39.1" %}
+{% set version = "1.40.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 3adea6eb45da9338343e501a5a7953d6b75e352d4e4902a65995209527cdc8b8
+  sha256: f09f919433317f53240cf7f81116bfc788bedd54afcb02f5ff7bcabe7bcab9a8
 
 build:
   # The build number of this package should always start from 100
@@ -43,7 +43,7 @@ requirements:
   run_constrained:
     # modin
     - pandas <=2.3.1
-    - modin >=0.35.0,<0.37.0
+    - modin >=0.36.0,<0.38.0
     # opentelemetry
     - opentelemetry-api >=1.0.0,<2.0.0
     - opentelemetry-sdk >=1.0.0,<2.0.0
@@ -127,7 +127,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    # Requires Snowflake connection to run upstream tests. See: https://github.com/snowflakedb/snowpark-python/blob/v1.36.0/tests/README.md
+    # Requires Snowflake connection to run upstream tests. See: https://github.com/snowflakedb/snowpark-python/blob/v1.40.0/tests/README.md
 
 about:
   home: https://github.com/snowflakedb/snowpark-python


### PR DESCRIPTION
snowpark-python 1.40.0 

**Destination channel:** Defaults

### Links

- [PKG-10056]
- dev_url:        https://github.com/snowflakedb/snowpark-python/tree/v1.40.0
- conda_forge:    None
- pypi:           https://pypi.org/project/snowpark-python/1.40.0
- pypi inspector: https://inspector.pypi.io/project/snowpark-python/1.40.0

### Explanation of changes:

- new version number


[PKG-10056]: https://anaconda.atlassian.net/browse/PKG-10056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ