### PR TITLE
snowpark-python 1.48.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.47.0" %}
+{% set version = "1.48.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: e4b4bfb24a52b50fe32746935fb6d0337183d57d3967ecd001c5cebe4a695a54
+  sha256: 1706a4f988032ebf12e9700ed295d91fdd098088ba18e64fa242f88dd4e2e5db
 
 build:
   # The build number of this package should always start from 100


### PR DESCRIPTION
snowpark-python 1.48.0 

**Destination channel:** Defaults

### Links

- [PKG-13158]
- dev_url:        https://github.com/snowflakedb/snowpark-python/tree/v1.48.0
- conda_forge:    None
- pypi:           https://pypi.org/project/snowpark-python/1.48.0
- pypi inspector: https://inspector.pypi.io/project/snowpark-python/1.48.0

### Explanation of changes:

- new version number


[PKG-13158]: https://anaconda.atlassian.net/browse/PKG-13158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ