### PR TITLE
snowpark-python 1.48.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.48.0" %}
+{% set version = "1.48.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 1706a4f988032ebf12e9700ed295d91fdd098088ba18e64fa242f88dd4e2e5db
+  sha256: 3095558d7cc543106ada155fb02e630f0446708919f5cc5b2acab997eb99433e
 
 build:
   # The build number of this package should always start from 100


### PR DESCRIPTION
snowpark-python 1.48.1 

**Destination channel:** Defaults

### Links

- [PKG-13344]
- dev_url:        https://github.com/snowflakedb/snowpark-python/tree/v1.48.1
- conda_forge:    None
- pypi:           https://pypi.org/project/snowpark-python/1.48.1
- pypi inspector: https://inspector.pypi.io/project/snowpark-python/1.48.1

### Explanation of changes:

- new version number


[PKG-13344]: https://anaconda.atlassian.net/browse/PKG-13344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ