### PR TITLE
snowpark-python 1.50.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake-snowpark-python" %}
-{% set version = "1.50.0" %}
+{% set version = "1.50.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 8af823326c2681333bf59ad3d6152b07098b7926165667a7fdcebd5adb53642f
+  sha256: 780a7595fa4fd8989a3519dd825d8de0a79b8dd98f6bf95c853a0b3f2df9db43
 
 build:
   # The build number of this package should always start from 100


### PR DESCRIPTION
snowpark-python 1.50.1 

**Destination channel:**  defaults

### Links

- [PKG-14696]
- dev_url:        https://github.com/snowflakedb/snowpark-python/tree/v1.50.1

### Explanation of changes:

- new version number


[PKG-14696]: https://anaconda.atlassian.net/browse/PKG-14696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ